### PR TITLE
add support for hong kong stocks

### DIFF
--- a/lib/quoter_yahoo.py
+++ b/lib/quoter_yahoo.py
@@ -5,6 +5,7 @@ import yfinance as yf
 Yahoo finance country/exchange code. For US stock,there is no prefix.
 for SH prefix need to be changed to '.SS' surfix.
 for SZ prefix need to be changed to '.SZ' surfix.
+for HK prefix need to be changed to '.KS' surfix.
 """
 def quote_yahoo(tickers):
     """ Get prices from yahoo finance APIs and return a dictionary of ticker:price as key:value pair.
@@ -31,6 +32,9 @@ def quote_yahoo(tickers):
             reformated_tickers.append(formated_ticker)
         elif ticker[:3] == 'SZ.':
             formated_ticker = ticker[3:] + '.SZ'
+            reformated_tickers.append(formated_ticker)
+        elif ticker[:3] == 'HK.':
+            formated_ticker = ticker[3:] + '.KS'
             reformated_tickers.append(formated_ticker)
 
     if(len(reformated_tickers) == 1):
@@ -60,6 +64,8 @@ def quote_yahoo(tickers):
                 restored_ticker = 'SH.' + tick[:-3]
             elif tick[-3:] == '.SZ':
                 restored_ticker = 'SZ.' + tick[:-3]
+            elif tick[-3:] == '.KS':
+                restored_ticker = 'HK.' + tick[:-3]
             else:
                 restored_ticker = 'US.' +tick.replace('-','.')
             ret_dict[restored_ticker]=close[tick][0]

--- a/tests/test_quote_yahoo.py
+++ b/tests/test_quote_yahoo.py
@@ -26,10 +26,11 @@ class TestGetPrices(unittest.TestCase):
         self.assertTrue(res['US.GOOG'] > 0)
         self.assertTrue(res['US.BRK.B'] > 0)
     def test_china(self):
-        res = qy.quote_yahoo(['SZ.000651', 'SH.000001'])
-        self.assertEqual(len(res), 2) # DUMMY GOOG will be added
+        res = qy.quote_yahoo(['SZ.000651', 'SH.000001','HK.016580'])
+        self.assertEqual(len(res), 3)
         self.assertTrue(res['SZ.000651'] > 0)
         self.assertTrue(res['SH.000001'] > 0)
+        self.assertTrue(res['HK.016580'] > 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Support 'HK' prefix in yahoo.
Hong Kong stocks are with surfix 'KS'