### PR TITLE
support muti exchange

### DIFF
--- a/lib/watcher.py
+++ b/lib/watcher.py
@@ -1,6 +1,7 @@
 #! /usr/local/bin/python3
 from .quoter import quote
 from .inflater import inflate
+from itertools import groupby
 
 def watch(conf):
     '''
@@ -17,9 +18,16 @@ def watch(conf):
       'US.MSFT': { 'upper': 100}
     }
     '''
-    prices = quote(list(conf.keys()))
-    if not prices:
-        return None
+    # partition keys by prefix
+    keys = list(conf.keys())
+    keys.sort()
+    prices = {}
+    for key, group in groupby(keys, lambda x: x[:3]):
+        parts = []
+        for thing in group:
+            parts.append(thing)
+        prices.update(quote(parts))
+
     alerts = {}
     for ticker, price in prices.items():
         limits = inflate(conf[ticker])

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -8,7 +8,7 @@ from lib import watcher
 class TestWatcher(unittest.TestCase):
 
     def test_empty(self):
-        self.assertEqual(watcher.watch({}), None)
+        self.assertEqual(watcher.watch({}), {})
 
     def test_happy(self):
         res = watcher.watch({
@@ -20,7 +20,7 @@ class TestWatcher(unittest.TestCase):
 
     def test_unhappy(self):
         res = watcher.watch({'unhappy': None})
-        self.assertEqual(res, None)
+        self.assertEqual(res, {})
 
     def test_none(self):
         res = watcher.watch({
@@ -63,6 +63,13 @@ class TestWatcher(unittest.TestCase):
         self.assertEqual(conf[ticker]['inflate'], inflate['inflate'])
         self.assertFalse('adjLower' in conf[ticker])
         self.assertFalse('adjUpper' in conf[ticker])
+
+    def test_partition(self):
+        conf={'SH.600004':{},'SH.600276':{}, 'US.GOOG':{}}
+        res = watcher.watch(conf)
+        self.assertTrue(conf['SH.600004']['price'] > 0)
+        self.assertTrue(conf['SH.600276']['price'] > 0)
+        self.assertTrue(conf['US.GOOG']['price'] > 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Yahoo does not support loading tickers from different exchange in the same call.
So partition by exchange first, then make separate calls to yahoo finance api to hide this detail from end users.